### PR TITLE
Changes for new reflex-dom-0.4. Remove warnings.

### DIFF
--- a/ReflexScreenWidget.cabal
+++ b/ReflexScreenWidget.cabal
@@ -1,5 +1,5 @@
 name:                ReflexScreenWidget
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Renders a CPU-generated image to a Canvas in realtime.
 description:         Please see README.md
 homepage:            http://github.com/maiavictor/ReflexScreenWidget
@@ -14,36 +14,38 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Reflex.Dom.Widget.Screen, Reflex.Dom.Widget.Screen.Test, Reflex.Dom.AnimationFrame
+  ghc-options:         -Wall
+  exposed-modules:     Reflex.Dom.Widget.Screen
+                     , Reflex.Dom.Widget.Screen.Test
+                     , Reflex.Dom.AnimationFrame
+                     , GHCJS.Canvas.BlitByteString
   other-extensions:    ViewPatterns, TypeFamilies, TemplateHaskell, MultiParamTypeClasses, RankNTypes
   build-depends:       base
-                     , reflex
                      , reflex-dom
                      , transformers
                      , containers
                      , ghcjs-dom
-                     , linear
                      , ghcjs-base
-                     , vector
                      , time
                      , bytestring
+                     , text
+
   default-language:    Haskell2010
+
 
 executable reflexScreenWidget
   hs-source-dirs:      src
   main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
-                     , reflex
                      , reflex-dom
                      , transformers
                      , containers
                      , ghcjs-dom
-                     , linear
                      , ghcjs-base
-                     , vector
                      , time
                      , bytestring
+                     , text
   default-language:    Haskell2010
 
 source-repository head

--- a/src/GHCJS/Canvas/BlitByteString.hs
+++ b/src/GHCJS/Canvas/BlitByteString.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE ScopedTypeVariables, NoMonomorphismRestriction, JavaScriptFFI, CPP #-}
+
+module GHCJS.Canvas.BlitByteString (blitByteString) where
+--
+-- Code recovered from old version of Screen.hs (before commit daac065 )
+--
+import Foreign.Ptr (Ptr)
+import GHCJS.Types (JSVal)
+
+#ifdef __GHCJS__
+foreign import javascript unsafe 
+    -- Arguments
+    --    canvas : JSHtmlElementCanvas
+    --    width  : JSNumber
+    --    height : JSNumber
+    --    pixels : Ptr a -- Pointer to a ByteString in the format below
+    "(function(){                                                     \
+        var cvs    = $1;                                              \
+        var width  = $2;                                              \
+        var height = $3;                                              \
+        var pixels = new Uint8ClampedArray($4.u8);                    \
+        cvs.width  = width;                                           \
+        cvs.height = height;                                          \
+        var ctx    = cvs.getContext('2d');                            \
+        ctx.putImageData(new ImageData(pixels, width, height), 0, 0); \
+    })()"
+    -- | Draw a Haskell ByteString to a JavaScript Canvas
+    blitByteString :: forall a . JSVal -> JSVal -> JSVal -> Ptr a -> IO ()
+#endif

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -20,10 +20,11 @@ blueScreen = do
     let blue   = [0, 0, 255, 255] -- [Red, Green, Blue, Alpha]
     let buffer = BS.pack $ concat $ replicate (width*height) blue
     let image  = ByteImageRgba width height buffer
-    screenCanvas <- screenWidget (constant image)
+    _ <- screenWidget $ constant image
     return ()
 
 -- Starts an widget with 3 screens.
+main :: IO ()
 main = do
     startTime <- getCurrentTime
     mainWidget $ do

--- a/src/Reflex/Dom/AnimationFrame.hs
+++ b/src/Reflex/Dom/AnimationFrame.hs
@@ -10,7 +10,7 @@ import Reflex.Dom (MonadWidget, Event, performEventAsync, getPostBuild)
 --   starting after a specified event.
 animationFrameFrom :: MonadWidget t m => Event t a -> m (Event t Double)
 animationFrameFrom = performEventAsync . fmap (const (void . liftIO . loop 0)) where 
-    loop d cb = inAnimationFrame ContinueAsync (\ d -> loop d cb) >> cb d
+    loop d cb = inAnimationFrame ContinueAsync (`loop` cb) >> cb d
 
 -- | Event that is fired continuously using onRequestAnimationFrame,
 --   starting after all widgets are built.

--- a/src/Reflex/Dom/Widget/Screen/Test.hs
+++ b/src/Reflex/Dom/Widget/Screen/Test.hs
@@ -5,7 +5,7 @@ module Reflex.Dom.Widget.Screen.Test where
 import Control.Monad (void)
 import Data.Time.Clock (UTCTime)
 import Data.Word (Word8)
-import Reflex.Dom (MonadWidget, Event, performEventAsync, getPostBuild, TickInfo, tickLossy, hold, mainWidget, _tickInfo_n)
+import Reflex.Dom (MonadWidget, tickLossy, hold, _tickInfo_n)
 import Reflex.Dom.Widget.Screen (screenWidget, ByteImageRgba, ByteImageRgba(ByteImageRgba))
 import qualified Data.ByteString as B
 
@@ -25,7 +25,7 @@ screenWidgetTestApp startTime renderWaves width height = void $ do
                         0 -> floor $ 255*(0.5+sin (fi dx/(7 + cos t * 3)+t*5)/2)
                         1 -> floor $ 255*(0.5+sin (fi dy/5+sin t * 7)/2)
                         2 -> floor $ 255*(0.75+sin (dist/2+(9+cos t * 3))/4)
-                        otherwise -> 255
+                        _ -> 255
             fi   = fromIntegral
             cx   = div width 2  :: Int
             cy   = div height 2 :: Int

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,24 +1,44 @@
-flags: {}
+# stack yaml starter file for reflex projects with ghc
 
-resolver: nightly-2015-12-05
-
-compiler: ghcjs-0.2.0.20151029_ghc-7.10.2
+resolver: lts-6.25
+compiler: ghcjs-0.2.0.9006025_ghc-7.10.3
 compiler-check: match-exact
-setup-info:
-  ghcjs:
-    source:
-      ghcjs-0.2.0.20151029_ghc-7.10.2:
-        url: "https://github.com/nrolland/ghcjs/releases/download/v0.2.0.20151029/ghcjs-0.2.0.20151029.tar.gz"
 
+setup-info:
+ ghcjs:
+   source:
+     ghcjs-0.2.0.9006025_ghc-7.10.3:
+       url: http://ghcjs.tolysz.org/lts-6.25-9006025.tar.gz
+       sha1: 3c87228579b55c05e227a7876682c2a7d4c9c007
+
+flags: {}
+extra-package-dbs: []
 packages:
-- location: '.'
+- '.'
 - location:
-    git: https://github.com/ryantrinkle/reflex-dom.git
-    commit: f4dbdd799260bc203f7f5cdce18362cb896f6d57 # ghcjs-improved-base-2 branch
+    git:  https://github.com/ghcjs/ghcjs.git
+    commit: 8c30beb939dadcb949b922856735080699d1d986
+  subdirs:
+  - lib/ghcjs-prim
+  extra-dep: true
+- location:
+    git: https://github.com/ghcjs/ghcjs-base.git
+    commit: dd7034ef8582ea8a175a71a988393a9d1ee86d6f
   extra-dep: true
 
+- location:
+    git: https://github.com/reflex-frp/reflex
+    commit: 91299fce0bb2caddfba35af6608df57dd31e3690
+  extra-dep: true
+
+- location:
+    git: https://github.com/reflex-frp/reflex-dom
+    commit: 66b6d35773fcb337ab38ebce02c4b23baeae721e
+  extra-dep: true
+
+
 extra-deps:
-  - reflex-0.3.2
-  - ref-tf-0.4
-  - these-0.6.1.0
-  - ghcjs-dom-0.2.3.0
+- these-0.6.2.1
+- prim-uniq-0.1.0.1
+- ref-tf-0.4.0.1
+- zenc-0.1.1


### PR DESCRIPTION
This is a pull request for issue #1 *Update to this package*. It contains the necessary changes for reflex-dom-0.4 (currently on Github) and fixes some warnings.

However it's not quite perfect:

I couldn't find the module *GHCJS.Canvas.BlitByteString* with the function *blitByteString*.
Therefore I recreated this module from an earlier commit and added it again. If you tell me where I can find this function, I'll change the pull request accordingly.

There is a problem with stack: It always unregisters the modules *ghcjs-dom* and *reflex*.
This makes rebuilds very time consuming. I opened an issue [https://github.com/commercialhaskell/stack/issues/3108](https://github.com/commercialhaskell/stack/issues/3108).